### PR TITLE
README typo/ removed extraneous `if`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **This project is in the early stages of development, it is not yet ready for real
 use. It will probably eat your laundry.**
 
-The RLS is provides a service that runs in the background, providing IDEs,
+The RLS provides a service that runs in the background, providing IDEs,
 editors, and other tools with information about Rust programs. It supports
 functionality such as 'goto definition', symbol search, reformatting, and code
 completion, and enables renaming and refactorings.


### PR DESCRIPTION
Figured this was just a typo
Typo in my typo fix, meant to title it 'Removed extraneous `is`