### PR TITLE
Added docstrings based on the language server protocol to …

### DIFF
--- a/src/actions_ls.rs
+++ b/src/actions_ls.rs
@@ -86,7 +86,11 @@ impl ActionHandler {
                             }
                             let mut diag = Diagnostic {
                                 range: Range::from_span(&method.spans[0]),
-                                severity: if method.level == "error" { 1 } else { 2 },
+                                severity: if method.level == "error" {
+                                    DiagnosticSeverity::Error
+                                } else {
+                                    DiagnosticSeverity::Warning
+                                },
                                 code: match method.code {
                                     Some(c) => c.code.clone(),
                                     None => String::new(),
@@ -118,17 +122,16 @@ impl ActionHandler {
                     // which had errors, but now don't. This instructs the IDE to clear
                     // errors for those files.
                     let results = self.previous_build_results.lock().unwrap();
-                    for k in results.keys() {
-                        notifications.push(NotificationMessage {
-                            jsonrpc: "2.0".into(),
-                            method: "textDocument/publishDiagnostics".to_string(),
-                            params: PublishDiagnosticsParams {
+                    for (k, v) in results.iter() {
+                        notifications.push(NotificationMessage::new(
+                            "textDocument/publishDiagnostics".to_string(),
+                            PublishDiagnosticsParams {
                                 uri: "file://".to_string() +
-                                        project_path + "/" +
-                                        k,
-                                diagnostics: results.get(k).unwrap().clone()
+                                    project_path + "/" +
+                                    k,
+                                diagnostics: v.clone()
                             }
-                        });
+                        ));
                     }
                 }
 

--- a/src/ls_server.rs
+++ b/src/ls_server.rs
@@ -458,13 +458,13 @@ pub trait Output {
 
         #[derive(Serialize)]
         struct ResponseFailure {
-            jsonrpc: String,
+            jsonrpc: &'static str,
             id: usize,
             error: ResponseError,
         }
 
         let rf = ResponseFailure {
-            jsonrpc: "2.0".to_owned(),
+            jsonrpc: "2.0",
             id: id,
             error: ResponseError {
                 code: METHOD_NOT_FOUND,
@@ -487,11 +487,9 @@ pub trait Output {
     }
 
     fn notify(&self, message: &str) {
-        let output = serde_json::to_string(&NotificationMessage {
-            jsonrpc: "2.0".to_owned(),
-            method: message.to_owned(),
-            params: (),
-        }).unwrap();
+        let output = serde_json::to_string(
+            &NotificationMessage::new(message.to_owned(), ())
+        ).unwrap();
         self.response(output);
     }
 }


### PR DESCRIPTION
I would like to learn more about the LSP, and contributing to this repo will be a good way for me to do so.

After looking at the code, I thought it would be helpful to have descriptions for some of the data structures that are being used, so I took them directly from the language server protocol page itself.

The documentation mentions that jsonrpc is always fixed at 2.0, so there is no need to keep it in a dynamically allocated string field, especially since it is is already present  [here](https://github.com/jonathandturner/rustls/blob/master/src/ls_server.rs#L484).

Serde has a open issue to automatically serialize numeric enums as numbers, but until that is completed, I added a serialization implementation for a new numeric struct - DiagnosticSeverity.