### PR TITLE
Use PathBuf and Path where necessary, and Url::from/to_file_path to convert between paths and file:// URLs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ os:
   - osx
 rust:
   - nightly
+script:
+  - cargo build --verbose
+  - SYS_ROOT=$(rustc --print sysroot) RUST_TEST_THREADS=1 cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -125,7 +125,7 @@ dependencies = [
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -255,7 +255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rls-analysis"
 version = "0.1.0"
-source = "git+https://github.com/nrc/rls-analysis#c7de77599daa7136c85f6c045c4998ff24a5fd5c"
+source = "git+https://github.com/nrc/rls-analysis#480bf1a9577aabb31952fc2ff4ad2e39e7c0bb58"
 dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -266,7 +266,7 @@ dependencies = [
 [[package]]
 name = "rls-vfs"
 version = "0.1.0"
-source = "git+https://github.com/nrc/rls-vfs#5d27352e192279e81aca666b1817c5968a942878"
+source = "git+https://github.com/nrc/rls-vfs#9c204a63e0e8cc99f023c88e238894f1dbc8df42"
 dependencies = [
  "rls-analysis 0.1.0 (git+https://github.com/nrc/rls-analysis)",
  "serde 0.8.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -576,7 +576,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "url"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -682,7 +682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-segmentation 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b905d0fc2a1f0befd86b0e72e31d1787944efef9d38b9358a9e92a69757f7e3b"
 "checksum unicode-width 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d6722facc10989f63ee0e20a83cd4e1714a9ae11529403ac7e0afd069abc39e"
 "checksum unicode-xid 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "36dff09cafb4ec7c8cf0023eb0b686cb6ce65499116a12201c9e11840ca01beb"
-"checksum url 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8527c62d9869a08325c38272b3f85668df22a65890c61a639d233dc0ed0b23a2"
+"checksum url 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ba5a45db1d2e0effb7a1c00cc73ffc63a973da8c7d1fcd5b46f24285ade6c54"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"
 "checksum walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"

--- a/src/actions_http.rs
+++ b/src/actions_http.rs
@@ -28,7 +28,7 @@ use vfs::Vfs;
 
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
 pub struct Position {
-    pub filepath: String,
+    pub filepath: PathBuf,
     pub line: usize,
     pub col: usize,
 }
@@ -100,7 +100,7 @@ pub fn find_refs(source: Input, analysis: Arc<AnalysisHost>) -> Vec<Span> {
     rustw_handle.join().ok().and_then(|t| t.ok()).unwrap_or(vec![])
 }
 
-pub fn fmt(file_name: &str, vfs: Arc<Vfs>) -> FmtOutput {
+pub fn fmt(file_name: &Path, vfs: Arc<Vfs>) -> FmtOutput {
     let path = PathBuf::from(file_name);
     let input = match vfs.load_file(&path) {
         Ok(s) => FmtInput::Text(s),
@@ -164,7 +164,7 @@ pub fn goto_def(source: Input, analysis: Arc<AnalysisHost>, vfs: Arc<Vfs>) -> Ou
                     let (line, col) = session.load_file(source_path)
                                              .point_to_coords(mtch.point)
                                              .unwrap();
-                    let fpath = source_path.to_str().unwrap().to_owned();
+                    let fpath = source_path.to_owned();
                     Some(Position {
                         filepath: fpath,
                         line: line,
@@ -218,7 +218,7 @@ pub fn title(source: Input, analysis: Arc<AnalysisHost>) -> Option<Title> {
     rustw_handle.join().ok()
 }
 
-pub fn symbols(file_name: String, analysis: Arc<AnalysisHost>) -> Vec<Symbol> {
+pub fn symbols(file_name: PathBuf, analysis: Arc<AnalysisHost>) -> Vec<Symbol> {
     let t = thread::current();
     let rustw_handle = thread::spawn(move || {
         let symbols = analysis.symbols(&file_name).unwrap_or(vec![]);

--- a/src/build.rs
+++ b/src/build.rs
@@ -50,7 +50,7 @@ use std::time::Duration;
 /// of success or failure. If the build was not run, the result indicates that
 /// it was squashed.
 pub struct BuildQueue {
-    build_dir: Mutex<Option<String>>,
+    build_dir: Mutex<Option<PathBuf>>,
     cmd_line: Mutex<Option<String>>,
     // True if a build is running.
     // Note I have been conservative with Ordering when accessing this atomic,
@@ -102,7 +102,7 @@ impl BuildQueue {
         }
     }
 
-    pub fn request_build(&self, build_dir: &str, priority: BuildPriority) -> BuildResult {
+    pub fn request_build(&self, build_dir: &Path, priority: BuildPriority) -> BuildResult {
         //println!("request_build, {} {:?}", build_dir, priority);
         // If there is a change in the project directory, then we can forget any
         // pending build and start straight with this new build.
@@ -256,7 +256,7 @@ impl BuildQueue {
             cmd.arg("--aBogusArgument");
             cmd.env("RUSTFLAGS", "-Zunstable-options -Zsave-analysis --error-format=json \
                                   -Zcontinue-parse-after-error -Zno-trans");
-            cmd.env("CARGO_TARGET_DIR", "target/rls");
+            cmd.env("CARGO_TARGET_DIR", &Path::new("target").join("rls"));
             cmd.current_dir(build_dir);
 
             let mut new_cmd_line = match cmd.output() {
@@ -294,7 +294,7 @@ impl BuildQueue {
     }
 
     // Runs a single instance of rustc. Runs in-process.
-    fn rustc(&self, cmd_line: &str, build_dir: &str) -> BuildResult {
+    fn rustc(&self, cmd_line: &str, build_dir: &Path) -> BuildResult {
         //println!("cmd_line: `{}`", cmd_line);
 
         let args: Vec<String> = cmd_line.split(' ').map(|s| s.to_owned()).collect();

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::path::PathBuf;
+
 use analysis::{raw, Span};
 use serde_json;
 
@@ -34,14 +36,14 @@ pub enum FmtOutput {
 
 #[derive(Debug, Deserialize)]
 pub struct ChangeInput {
-    pub project_path: String,
+    pub project_path: PathBuf,
     pub changes: Vec<Change>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SaveInput {
-    pub project_path: String,
-    pub saved_file: String,
+    pub project_path: PathBuf,
+    pub saved_file: PathBuf,
 }
 
 macro_rules! from_bytes {


### PR DESCRIPTION
This also requires url v1.2.2 or higher for Url::to_file_path to work with URL-encoded drive letters on Windows.

---

Will need another update before it can be merged to update the rls-analysis and rls-vfs commit hashes in Cargo.lock after those PRs are merged.